### PR TITLE
README: clarify api host

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ You can get help of various args by running:
 im --help
 ```
 The following are required arguments:
-- `--api-key` - Immich API key
-- `--api-host` - Immich API host
+- `--api-key` - Immich API key (create one from Immich by going to Account Settings > API Keys)
+- `--api-host` - Immich API host (this is your Immich server URL **with `/api` appended to it**)
 - `--original-path` - Path to local albums
 - `--replace-path` - Path as seen by Immich host
 


### PR DESCRIPTION
Turns out that https://github.com/alvistar/immich-albums/issues/5 is also exactly the error you get when missing `/api` on your server URL. Clarifying the readme to hopefully help others.

The alternative would be to check for a response from `{api_host}/server-info` and otherwise try `{api_host}/api/server-info` - and exit with an error if neither works.

Sidenote, you don't actually need to explicitly activate the virtualenv, `poetry run im ...` works

Thanks again for an amazingly useful project!